### PR TITLE
eval_xg3_avail(): bugfix in firstyear-lastyear calculation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: watina
 Title: Querying & Processing Data From The INBO Watina Database (mainly groundwater data)
-Version: 0.1.0.9017
+Version: 0.1.0.9020
 Description: The R-package watina contains functions to query
     and process data from the Watina database at the Research Institute for
     Nature and Forest (INBO). This database provides

--- a/R/eval.R
+++ b/R/eval.R
@@ -71,11 +71,14 @@ eval_xg3_avail <- function(data,
                  .data$xg3_variable) %>%
         summarise(
             nryears = sum(.data$available),
-            firstyear = ifelse(.data$nryears > 0,
-                               min(.data$hydroyear),
+            firstyear = ifelse(first(.data$nryears) > 0,
+                               min(ifelse(.data$available,
+                                          .data$hydroyear,
+                                          NA),
+                                   na.rm = TRUE),
                                NA),
-            lastyear = ifelse(.data$nryears > 0,
-                              max(.data$hydroyear),
+            lastyear = ifelse(first(.data$nryears) > 0,
+                              max(.data$hydroyear * .data$available),
                               NA)
         ) %>%
         ungroup


### PR DESCRIPTION
Fixes #19.

End result of the example of `eval_xg3_avail()` now begins as:

```r
   loc_code xg3_variable nryears firstyear lastyear
   <chr>    <chr>          <int>     <int>    <int>
 1 KALP022  combined           3      2014     2016
 2 KALP022  lg3_lcl            3      2014     2016
 3 KALP022  vg3_lcl            4      2014     2017

```