### PR TITLE
Fix external documentation links to avoid Rd warnings at installation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: watina
 Title: Querying & Processing Data From The INBO Watina Database (mainly groundwater data)
-Version: 0.2.0.9000
+Version: 0.2.1
 Description: The R-package watina contains functions to query
     and process data from the Watina database at the Research Institute for
     Nature and Forest (INBO). This database provides

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: watina
 Title: Querying & Processing Data From The INBO Watina Database (mainly groundwater data)
-Version: 0.2.0
+Version: 0.2.0.9000
 Description: The R-package watina contains functions to query
     and process data from the Watina database at the Research Institute for
     Nature and Forest (INBO). This database provides

--- a/R/get.R
+++ b/R/get.R
@@ -56,7 +56,7 @@
 #' Do you want to spatially join the attribute columns of \code{mask} to the
 #' resulting tibble?
 #' The spatial join is executed with
-#' \code{\link[sf:st_intersects]{st_intersects()}} as the topological operator.
+#' \code{\link[sf:geos_binary_pred]{st_intersects()}} as the topological operator.
 #' Beware: if the same location intersects with more than one element of
 #' \code{mask} (taking into account the value of \code{buffer}), that location
 #' will occur multiple times in the result.
@@ -86,7 +86,7 @@
 #' If \code{FALSE} (the default), a \code{tbl_lazy} object is returned
 #' (lazy query).
 #' Hence the result can be further built upon before retrieving data with
-#' \code{\link[dplyr:collect]{collect()}}.
+#' \code{\link[dplyr:compute]{collect()}}.
 #'
 #' @return
 #' By default, a \code{tbl_lazy} object.
@@ -627,7 +627,7 @@ get_xg3 <- function(locs,
 #'
 #' @param startdate First date of the timeframe, as a string.
 #' The string must use a formatting of the order 'day month year',
-#' i.e. a format which can be interpreted by \code{\link[lubridate]{dmy}}.
+#' i.e. a format which can be interpreted by \code{\link[lubridate:ymd]{dmy}}.
 #'
 #' Examples:
 #' \code{"16-1-2005"},

--- a/R/sf.R
+++ b/R/sf.R
@@ -9,7 +9,7 @@
 #' As locations in Watina are typically defined by their X/Y coordinates,
 #' this function eases the conversion to spatial data.
 #' To later remove all spatial information from the result, you can use
-#' \code{\link[sf:st_drop_geometry]{sf::st_drop_geometry()}}.
+#' \code{\link[sf:st_geometry]{sf::st_drop_geometry()}}.
 #'
 #' @param df A dataframe with X and Y coordinates in meters, assumed to be in
 #' the Belgian Lambert 72 CRS (EPSG-code 31370).

--- a/man/as_points.Rd
+++ b/man/as_points.Rd
@@ -32,7 +32,7 @@ It converts the dataframe into an \code{sf} points object in the same CRS.
 As locations in Watina are typically defined by their X/Y coordinates,
 this function eases the conversion to spatial data.
 To later remove all spatial information from the result, you can use
-\code{\link[sf:st_drop_geometry]{sf::st_drop_geometry()}}.
+\code{\link[sf:st_geometry]{sf::st_drop_geometry()}}.
 }
 \examples{
 library(tibble)

--- a/man/get_chem.Rd
+++ b/man/get_chem.Rd
@@ -20,7 +20,7 @@ See \code{\link{connect_watina}} to generate one.}
 
 \item{startdate}{First date of the timeframe, as a string.
 The string must use a formatting of the order 'day month year',
-i.e. a format which can be interpreted by \code{\link[lubridate]{dmy}}.
+i.e. a format which can be interpreted by \code{\link[lubridate:ymd]{dmy}}.
 
 Examples:
 \code{"16-1-2005"},
@@ -89,7 +89,7 @@ the conditions imposed by \code{en_range} and \code{en_exclude_na}
 If \code{FALSE} (the default), a \code{tbl_lazy} object is returned
 (lazy query).
 Hence the result can be further built upon before retrieving data with
-\code{\link[dplyr:collect]{collect()}}.}
+\code{\link[dplyr:compute]{collect()}}.}
 }
 \value{
 By default, a \code{tbl_lazy} object.

--- a/man/get_locs.Rd
+++ b/man/get_locs.Rd
@@ -48,7 +48,7 @@ The CRS must be Belgian Lambert 72 (EPSG-code
 Do you want to spatially join the attribute columns of \code{mask} to the
 resulting tibble?
 The spatial join is executed with
-\code{\link[sf:st_intersects]{st_intersects()}} as the topological operator.
+\code{\link[sf:geos_binary_pred]{st_intersects()}} as the topological operator.
 Beware: if the same location intersects with more than one element of
 \code{mask} (taking into account the value of \code{buffer}), that location
 will occur multiple times in the result.
@@ -85,7 +85,7 @@ If provided, only locations are returned that are present in this vector.}
 If \code{FALSE} (the default), a \code{tbl_lazy} object is returned
 (lazy query).
 Hence the result can be further built upon before retrieving data with
-\code{\link[dplyr:collect]{collect()}}.}
+\code{\link[dplyr:compute]{collect()}}.}
 }
 \value{
 By default, a \code{tbl_lazy} object.

--- a/man/get_xg3.Rd
+++ b/man/get_xg3.Rd
@@ -46,7 +46,7 @@ If \code{TRUE} (the default), the XG3 values calculations also use estimated
 If \code{FALSE} (the default), a \code{tbl_lazy} object is returned
 (lazy query).
 Hence the result can be further built upon before retrieving data with
-\code{\link[dplyr:collect]{collect()}}.}
+\code{\link[dplyr:compute]{collect()}}.}
 }
 \value{
 By default, a \code{tbl_lazy} object.


### PR DESCRIPTION
This should solve the former warnings during installation of the `watina` package. To be tested, by installing from the `rd_warning` branch:

```r
remotes::install_github("inbo/watina", ref = "rd_warning")
```