### PR TITLE
 get_locs(): add 'filterdepth_na' argument

### DIFF
--- a/R/get.R
+++ b/R/get.R
@@ -32,6 +32,9 @@
 #' The second vector element cannot be smaller than the first.
 #' With \code{obswells = FALSE}, a location is kept whenever one observation
 #' well fulfills the criterion.
+#' @param filterdepth_na Logical.
+#' Are observation wells with missing filterdepth value to be included?
+#' Defaults to \code{FALSE}.
 #' @param obswells Logical.
 #' If \code{TRUE}, the returned object distinguishes all observation wells that
 #' meet the \code{filterdepth_range} criterion.
@@ -177,6 +180,7 @@
 #' group_by
 get_locs <- function(con,
                      filterdepth_range = c(0, 3),
+                     filterdepth_na = FALSE,
                      obswells = FALSE,
                      mask = NULL,
                      join_mask = FALSE,
@@ -202,6 +206,7 @@ get_locs <- function(con,
     assert_that(is.flag(join_mask))
     assert_that(is.flag(collect))
     assert_that(is.flag(obswells))
+    assert_that(is.flag(filterdepth_na))
 
     if (!is.null(mask) & !collect) {
         message("As a mask always invokes a collect(), the argument 'collect = FALSE' will be ignored.")
@@ -284,12 +289,30 @@ get_locs <- function(con,
                                                        "CLD")),
                   by = "MeetpuntWID") %>%
         mutate(filterdepth = .data$PeilbuisLengte -
-                                .data$ReferentieNiveauMaaiveld) %>%
-        filter(.data$MeetpuntTypeCode == "P" &
-                   .data$filterdepth <= max_filterdepth &
-                   .data$filterdepth >= min_filterdepth |
-                   .data$MeetpuntTypeCode != "P"
-               ) %>%
+                                .data$ReferentieNiveauMaaiveld)
+
+    if (filterdepth_na) {
+        locs <-
+            locs %>%
+            filter(
+                (.data$MeetpuntTypeCode == "P" &
+                       (.data$filterdepth <= max_filterdepth &
+                       .data$filterdepth >= min_filterdepth |
+                           is.na(.data$filterdepth))) |
+                       .data$MeetpuntTypeCode != "P"
+            )
+    } else {
+        locs <-
+            locs %>%
+            filter(.data$MeetpuntTypeCode == "P" &
+                       .data$filterdepth <= max_filterdepth &
+                       .data$filterdepth >= min_filterdepth |
+                       .data$MeetpuntTypeCode != "P"
+            )
+    }
+
+    locs <-
+        locs %>%
         select(loc_wid = .data$MeetpuntWID,
                loc_code = .data$MeetpuntCode,
                area_code = .data$GebiedCode,

--- a/R/get.R
+++ b/R/get.R
@@ -122,6 +122,12 @@
 #'          loc_type = c("P", "S"),
 #'          collect = TRUE)
 #'
+#' get_locs(watina,
+#'          area_codes = c("KAL", "KBR"),
+#'          loc_type = c("P", "S"),
+#'          filterdepth_na = TRUE,
+#'          collect = TRUE)
+#'
 #' # Mark the different output of:
 #'   get_locs(watina,
 #'            loc_vec = c("KBRP081", "KBRP090", "KBRP095", "KBRS001"),

--- a/R/get.R
+++ b/R/get.R
@@ -21,6 +21,9 @@
 #' \code{soilsurf_ost}, which then
 #' correspond to the most recent observation well
 #' (per location) that meets the criteria on filterdepth.
+#' Mind that \code{obswells = FALSE} and \code{filterdepth_na = TRUE} may lead
+#' to missing filterdepth values at locations which do have a
+#' value for an older observation well, but not for the most recent one.
 #'
 #'
 #' @param con A \code{DBIConnection} object to Watina.

--- a/man/get_locs.Rd
+++ b/man/get_locs.Rd
@@ -131,6 +131,9 @@ In the latter case, this refers to the variables \code{filterdepth} and
 \code{soilsurf_ost}, which then
 correspond to the most recent observation well
 (per location) that meets the criteria on filterdepth.
+Mind that \code{obswells = FALSE} and \code{filterdepth_na = TRUE} may lead
+to missing filterdepth values at locations which do have a
+value for an older observation well, but not for the most recent one.
 }
 \examples{
 \dontrun{

--- a/man/get_locs.Rd
+++ b/man/get_locs.Rd
@@ -154,6 +154,12 @@ get_locs(watina,
          loc_type = c("P", "S"),
          collect = TRUE)
 
+get_locs(watina,
+         area_codes = c("KAL", "KBR"),
+         loc_type = c("P", "S"),
+         filterdepth_na = TRUE,
+         collect = TRUE)
+
 # Mark the different output of:
   get_locs(watina,
            loc_vec = c("KBRP081", "KBRP090", "KBRP095", "KBRS001"),

--- a/man/get_locs.Rd
+++ b/man/get_locs.Rd
@@ -7,6 +7,7 @@
 get_locs(
   con,
   filterdepth_range = c(0, 3),
+  filterdepth_na = FALSE,
   obswells = FALSE,
   mask = NULL,
   join_mask = FALSE,
@@ -30,6 +31,10 @@ This condition is only applied to groundwater piezometers.
 The second vector element cannot be smaller than the first.
 With \code{obswells = FALSE}, a location is kept whenever one observation
 well fulfills the criterion.}
+
+\item{filterdepth_na}{Logical.
+Are observation wells with missing filterdepth value to be included?
+Defaults to \code{FALSE}.}
 
 \item{obswells}{Logical.
 If \code{TRUE}, the returned object distinguishes all observation wells that


### PR DESCRIPTION
If `TRUE`, the result includes wells with missing filterdepth. This was not possible before.
Defaults to `FALSE`.