### PR TITLE
Version 0.2.6: redo soilsurf_ost calculation in get_locs()

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -4,7 +4,7 @@
     "license": "other-open",
     "upload_type": "software",
     "access_right": "open",
-    "version": "0.2.5",
+    "version": "0.2.6",
     "creators": [
         {
             "name": "Vanderhaeghe, Floris",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: watina
 Title: Querying And Processing Data From The INBO Watina Database
-Version: 0.2.5
+Version: 0.2.6
 Description: The R-package watina contains functions to query
     and process data from the Watina database at the Research Institute for
     Nature and Forest (INBO). This database primarily provides

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# watina 0.2.6
+
+- Redo fix `get_locs()`: calculation of `soilsurf_ost` (#43)
+
 # watina 0.2.5
 
 - Bugfix in `get_locs()`: calculation of `soilsurf_ost` (#42)

--- a/R/get.R
+++ b/R/get.R
@@ -290,6 +290,9 @@ get_locs <- function(con,
                    .data$filterdepth >= min_filterdepth |
                    .data$MeetpuntTypeCode != "P"
                ) %>%
+        mutate(soilsurf_ost =
+                   .data$ReferentieNiveauTAW -
+                   .data$ReferentieNiveauMaaiveld) %>%
         select(loc_wid = .data$MeetpuntWID,
                loc_code = .data$MeetpuntCode,
                area_code = .data$GebiedCode,
@@ -303,9 +306,7 @@ get_locs <- function(con,
                obswell_code = .data$PeilpuntCode,
                obswell_rank = .data$PeilpuntVersie,
                .data$filterdepth,
-               soilsurf_ost =
-                   .data$ReferentieNiveauTAW -
-                   .data$ReferentieNiveauMaaiveld) %>%
+               .data$soilsurf_ost) %>%
         distinct %>%
         arrange(.data$area_code,
                 .data$loc_code,


### PR DESCRIPTION
Previous fix (#42) erroneously used a calculation inside `select()`.
That gave no error, but it did drop the `soilsurf_ost` variable.
Now fixed with `mutate()`.