### PR TITLE
get_xg3(), get_chem(): a fix for copy_to issue

### DIFF
--- a/R/get.R
+++ b/R/get.R
@@ -810,7 +810,8 @@ get_xg3 <- function(locs,
 
         locs <-
             copy_to(con,
-                    locs) %>%
+                    locs,
+                    "##locs") %>%
             inner_join(tbl(con, "vwDimMeetpunt") %>%
                           select(loc_wid = .data$MeetpuntWID,
                                  loc_code = .data$MeetpuntCode),
@@ -1087,7 +1088,8 @@ get_chem <- function(locs,
 
         locs <-
             copy_to(con,
-                    locs) %>%
+                    locs,
+                    "##locs") %>%
             inner_join(tbl(con, "vwDimMeetpunt") %>%
                            select(loc_wid = .data$MeetpuntWID,
                                   loc_code = .data$MeetpuntCode),


### PR DESCRIPTION
This is a workaround that fixes issue #55. The issue should be solved more conveniently by the next CRAN release of the `odbc` package. (Currently, it is fixed in their master branch by https://github.com/r-dbi/odbc/pull/361).

However this hardening in `watina` should work for both current and future CRAN releases, hence this 'temporary' fix will be incorporated in the next release. A slightly more elegant approach is in the `odbcgithub_copy_to` branch for now but will only work with the next `odbc` release.