### PR TITLE
Do not arrange() lazy objects within functions (unless always collected immediately after)

### DIFF
--- a/R/eval.R
+++ b/R/eval.R
@@ -33,7 +33,7 @@
 #' mydata <-
 #'  mylocs %>%
 #'  get_xg3(watina, 2014)
-#' mydata
+#' mydata %>% arrange(loc_code, hydroyear)
 #' eval_xg3_avail(mydata,
 #'                xg3_type = c("L", "V"))
     #' # Disconnect:
@@ -340,7 +340,7 @@ qualify_xg3 <- function(data,
 #' mydata <-
 #'  mylocs %>%
 #'  get_xg3(watina, 1900)
-#' mydata
+#' mydata %>% arrange(loc_code, hydroyear)
 #' mydata %>%
 #'   eval_xg3_series(xg3_type = c("L", "V"),
 #'                   max_gap = 2,
@@ -591,7 +591,7 @@ eval_xg3_series <- function(data,
 #' mydata <-
 #'  mylocs %>%
 #'  get_chem(watina, "1/1/2010")
-#' mydata
+#' mydata %>% arrange(loc_code, date, chem_variable)
 #' mydata %>%
 #'   pull(date) %>%
 #'   lubridate::year(.) %>%

--- a/R/eval.R
+++ b/R/eval.R
@@ -676,7 +676,11 @@ date, lab_sample_id, chem_variable, value, unit, below_loq."
         filter(.data$chem_variable %in% chem_var)
 
     if (inherits(data, "tbl_lazy")) {
-        data <- collect(data)
+        data <-
+            collect(data) %>%
+            arrange(.data$loc_code,
+                    .data$date,
+                    .data$chem_variable)
     }
 
     if (!missing(chem_var)) {

--- a/R/extract.R
+++ b/R/extract.R
@@ -69,7 +69,7 @@
 #' mydata <-
 #'  mylocs %>%
 #'  get_xg3(watina, 1900)
-#' mydata
+#' mydata %>% arrange(loc_code, hydroyear)
 #' mydata %>%
 #'   extract_xg3_series(xg3_type = c("L", "V"),
 #'                      max_gap = 2,

--- a/R/get.R
+++ b/R/get.R
@@ -211,7 +211,8 @@
 #'          bbox = c(xmin = 1.4e+5,
 #'                   xmax = 1.7e+5,
 #'                   ymin = 1.6e+5,
-#'                   ymax = 1.9e+5))
+#'                   ymax = 1.9e+5)) %>%
+#'     arrange(area_code, loc_code)
 #'
 #' get_locs(watina,
 #'          area_codes = c("KAL", "KBR"),
@@ -759,17 +760,22 @@ get_locs <- function(con,
 #' watina <- connect_watina()
 #' library(dplyr)
 #' mylocs <- get_locs(watina, area_codes = "KAL")
-#' mylocs %>% get_xg3(watina, 2010)
+#' mylocs %>%
+#'     get_xg3(watina, 2010) %>%
+#'     arrange(loc_code, hydroyear)
 #' mylocs %>% get_xg3(watina, 2010, collect = TRUE)
-#' mylocs %>% get_xg3(watina, 2010, vert_crs = "ostend")
+#' mylocs %>%
+#'     get_xg3(watina, 2010, vert_crs = "ostend") %>%
+#'     arrange(loc_code, hydroyear)
 #'
 #' # joining results to mylocs:
 #' mylocs %>%
-#'   get_xg3(watina, 2010) %>%
-#'   left_join(mylocs %>%
-#'             select(-loc_wid),
-#'             .) %>%
-#'   collect
+#'     get_xg3(watina, 2010) %>%
+#'     left_join(mylocs %>%
+#'               select(-loc_wid),
+#'               .) %>%
+#'     collect %>%
+#'     arrange(loc_code, hydroyear)
 #'
 #' # Disconnect:
 #' DBI::dbDisconnect(watina)
@@ -1012,9 +1018,14 @@ get_xg3 <- function(locs,
 #' watina <- connect_watina()
 #' library(dplyr)
 #' mylocs <- get_locs(watina, area_codes = "ZWA")
-#' mylocs %>% get_chem(watina, "1/1/2017")
-#' mylocs %>% get_chem(watina, "1/1/2017", collect = TRUE)
-#' mylocs %>% get_chem(watina, "1/1/2017", conc_type = "eq")
+#' mylocs %>%
+#'     get_chem(watina, "1/1/2017") %>%
+#'     arrange(loc_code, date, chem_variable)
+#' mylocs %>%
+#'     get_chem(watina, "1/1/2017", collect = TRUE)
+#' mylocs %>%
+#'     get_chem(watina, "1/1/2017", conc_type = "eq") %>%
+#'     arrange(loc_code, date, chem_variable)
 #'
 #' # compare the number of returned rows:
 #' mylocs %>% get_chem(watina, "1/1/2017") %>% count
@@ -1034,7 +1045,8 @@ get_xg3 <- function(locs,
 #'     left_join(mylocs %>%
 #'                   select(-loc_wid),
 #'               .) %>%
-#'     collect
+#'     collect %>%
+#'     arrange(loc_code, date, chem_variable)
 #'
 #' # Disconnect:
 #' DBI::dbDisconnect(watina)

--- a/R/get.R
+++ b/R/get.R
@@ -702,6 +702,18 @@ get_locs <- function(con,
 #' Why truncate, and why truncate by default?
 #' When to choose which \code{vert_crs}?)
 #'
+#' @md
+#'
+#' @note
+#' Up to and including `watina 0.3.0`, the result was sorted according to
+#' `loc_code` and `hydroyear`, both for the lazy query and the
+#' collected result.
+#' Later versions avoid sorting in case of a lazy result, because
+#' otherwise, when using the result inside another lazy query, this led to
+#' 'ORDER BY' constructs in SQL subqueries, which must be avoided.
+#' If you like to print the lazy object in a sorted manner, you must add
+#' `%>% arrange(...)` yourself.
+#'
 #' @param locs A \code{tbl_lazy} object or a dataframe, with at least a column
 #' \code{loc_code} that defines the locations for which values are to be
 #' returned.
@@ -854,13 +866,13 @@ get_xg3 <- function(locs,
                local = xg3 %>% select(-contains("ost")),
                ostend = xg3 %>% select(-contains("lcl")),
                both = xg3
-               ) %>%
-        arrange(.data$loc_code,
-                .data$hydroyear)
+               )
 
     if (collect) {
         xg3 <-
             xg3 %>%
+            arrange(.data$loc_code,
+                    .data$hydroyear) %>%
             collect
     }
 

--- a/R/get.R
+++ b/R/get.R
@@ -139,6 +139,18 @@
 #' retained observation well.
 #' It is ignored if \code{obswells = TRUE}.
 #'
+#' @md
+#'
+#' @note
+#' Up to and including `watina 0.3.0`, the result was sorted according to
+#' `area_code`, `loc_code` and (for observation wells) `obswell_rank`,
+#' both for the lazy query and the collected result.
+#' Later versions avoid sorting in case of a lazy result, because
+#' otherwise, when using the result inside another lazy query, this led to
+#' 'ORDER BY' constructs in SQL subqueries, which must be avoided.
+#' If you like to print the lazy object in a sorted manner, you must add
+#' `%>% arrange(...)` yourself.
+#'
 #' @param mask An optional geospatial filter of class \code{sf}.
 #' If provided, only locations that intersect with \code{mask} will be returned,
 #' with the value of \code{buffer} taken into account.
@@ -455,10 +467,7 @@ get_locs <- function(con,
                measuringref_ost = .data$ReferentieNiveauTAW,
                .data$tubelength,
                .data$filterlength,
-               .data$filterdepth) %>%
-        arrange(.data$area_code,
-                .data$loc_code,
-                .data$obswell_rank)
+               .data$filterdepth)
 
     if (filterdepth_guess) {
         locs <-
@@ -492,12 +501,6 @@ get_locs <- function(con,
                        .data$loc_typecode != "P"
             )
     }
-
-    locs <-
-        locs %>%
-        arrange(.data$area_code,
-                .data$loc_code,
-                .data$obswell_rank)
 
     if (!obswells) {
 
@@ -597,9 +600,7 @@ get_locs <- function(con,
                    -.data$obswell_count,
                    -.data$obswell_maxrank,
                    -.data$obswell_maxrank_fd,
-                   -.data$obswell_maxrank_sso) %>%
-            arrange(.data$area_code,
-                    .data$loc_code)
+                   -.data$obswell_maxrank_sso)
     }
 
     if (!is.null(mask)) {

--- a/R/get.R
+++ b/R/get.R
@@ -906,6 +906,18 @@ get_xg3 <- function(locs,
 #'
 #' TO BE ADDED: What is electroneutrality and why is it used as a criterion?
 #'
+#' @md
+#'
+#' @note
+#' Up to and including `watina 0.3.0`, the result was sorted according to
+#' `loc_code`, `date` and `chem_variable`, both for the lazy query and the
+#' collected result.
+#' Later versions avoid sorting in case of a lazy result, because
+#' otherwise, when using the result inside another lazy query, this led to
+#' 'ORDER BY' constructs in SQL subqueries, which must be avoided.
+#' If you like to print the lazy object in a sorted manner, you must add
+#' `%>% arrange(...)` yourself.
+#'
 #' @param startdate First date of the timeframe, as a string.
 #' The string must use a formatting of the order 'day month year',
 #' i.e. a format which can be interpreted by \code{\link[lubridate:ymd]{dmy}}.
@@ -1258,14 +1270,14 @@ get_chem <- function(locs,
                                              .data$unit))
         ) %>%
         select(-contains("value_"), -.data$provide_eq_unit) %>%
-        mutate(unit = ifelse(.data$unit == "/", NA, .data$unit)) %>%
-        arrange(.data$loc_code,
-                .data$date,
-                .data$chem_variable)
+        mutate(unit = ifelse(.data$unit == "/", NA, .data$unit))
 
     if (collect) {
         chem <-
             chem %>%
+            arrange(.data$loc_code,
+                    .data$date,
+                    .data$chem_variable) %>%
             collect
     }
 

--- a/R/selectlocs.R
+++ b/R/selectlocs.R
@@ -252,7 +252,7 @@
 #' mydata <-
 #'  mylocs %>%
 #'  get_xg3(watina, 2000)
-#' mydata
+#' mydata %>% arrange(loc_code, hydroyear)
 #' # Number of locations in mydata:
 #' mydata %>% distinct(loc_code) %>% count
 #' # Number of hydrological years per location and XG3 variable:
@@ -876,7 +876,7 @@ selectlocs_xg3 <- function(data,
 #' mydata <-
 #'     mylocs %>%
 #'     get_chem(watina, "1/1/2010")
-#' mydata
+#' mydata %>% arrange(loc_code, date, chem_variable)
 #' mydata %>%
 #'     pull(date) %>%
 #'     lubridate::year(.) %>%

--- a/man/eval_chem.Rd
+++ b/man/eval_chem.Rd
@@ -117,7 +117,7 @@ mylocs <- get_locs(watina, area_codes = "ZWA")
 mydata <-
  mylocs \%>\%
  get_chem(watina, "1/1/2010")
-mydata
+mydata \%>\% arrange(loc_code, date, chem_variable)
 mydata \%>\%
   pull(date) \%>\%
   lubridate::year(.) \%>\%

--- a/man/eval_xg3_avail.Rd
+++ b/man/eval_xg3_avail.Rd
@@ -45,7 +45,7 @@ mylocs <- get_locs(watina, area_codes = "KAL")
 mydata <-
  mylocs \%>\%
  get_xg3(watina, 2014)
-mydata
+mydata \%>\% arrange(loc_code, hydroyear)
 eval_xg3_avail(mydata,
                xg3_type = c("L", "V"))
 # Disconnect:

--- a/man/eval_xg3_series.Rd
+++ b/man/eval_xg3_series.Rd
@@ -117,7 +117,7 @@ mylocs <- get_locs(watina, area_codes = "KAL")
 mydata <-
  mylocs \%>\%
  get_xg3(watina, 1900)
-mydata
+mydata \%>\% arrange(loc_code, hydroyear)
 mydata \%>\%
   eval_xg3_series(xg3_type = c("L", "V"),
                   max_gap = 2,

--- a/man/extract_xg3_series.Rd
+++ b/man/extract_xg3_series.Rd
@@ -82,7 +82,7 @@ mylocs <- get_locs(watina, area_codes = "KAL")
 mydata <-
  mylocs \%>\%
  get_xg3(watina, 1900)
-mydata
+mydata \%>\% arrange(loc_code, hydroyear)
 mydata \%>\%
   extract_xg3_series(xg3_type = c("L", "V"),
                      max_gap = 2,

--- a/man/get_chem.Rd
+++ b/man/get_chem.Rd
@@ -151,9 +151,14 @@ If you like to print the lazy object in a sorted manner, you must add
 watina <- connect_watina()
 library(dplyr)
 mylocs <- get_locs(watina, area_codes = "ZWA")
-mylocs \%>\% get_chem(watina, "1/1/2017")
-mylocs \%>\% get_chem(watina, "1/1/2017", collect = TRUE)
-mylocs \%>\% get_chem(watina, "1/1/2017", conc_type = "eq")
+mylocs \%>\%
+    get_chem(watina, "1/1/2017") \%>\%
+    arrange(loc_code, date, chem_variable)
+mylocs \%>\%
+    get_chem(watina, "1/1/2017", collect = TRUE)
+mylocs \%>\%
+    get_chem(watina, "1/1/2017", conc_type = "eq") \%>\%
+    arrange(loc_code, date, chem_variable)
 
 # compare the number of returned rows:
 mylocs \%>\% get_chem(watina, "1/1/2017") \%>\% count
@@ -173,7 +178,8 @@ get_chem(watina, "1/1/2017") \%>\%
     left_join(mylocs \%>\%
                   select(-loc_wid),
               .) \%>\%
-    collect
+    collect \%>\%
+    arrange(loc_code, date, chem_variable)
 
 # Disconnect:
 DBI::dbDisconnect(watina)

--- a/man/get_chem.Rd
+++ b/man/get_chem.Rd
@@ -136,6 +136,16 @@ To retrieve all data from all water samples, use \code{en_range = c(-1, 1)}.
 
 TO BE ADDED: What is electroneutrality and why is it used as a criterion?
 }
+\note{
+Up to and including \verb{watina 0.3.0}, the result was sorted according to
+\code{loc_code}, \code{date} and \code{chem_variable}, both for the lazy query and the
+collected result.
+Later versions avoid sorting in case of a lazy result, because
+otherwise, when using the result inside another lazy query, this led to
+'ORDER BY' constructs in SQL subqueries, which must be avoided.
+If you like to print the lazy object in a sorted manner, you must add
+\verb{\%>\% arrange(...)} yourself.
+}
 \examples{
 \dontrun{
 watina <- connect_watina()

--- a/man/get_locs.Rd
+++ b/man/get_locs.Rd
@@ -242,7 +242,8 @@ get_locs(watina,
          bbox = c(xmin = 1.4e+5,
                   xmax = 1.7e+5,
                   ymin = 1.6e+5,
-                  ymax = 1.9e+5))
+                  ymax = 1.9e+5)) \%>\%
+    arrange(area_code, loc_code)
 
 get_locs(watina,
          area_codes = c("KAL", "KBR"),

--- a/man/get_locs.Rd
+++ b/man/get_locs.Rd
@@ -222,6 +222,16 @@ Here, the term 'observation well' is used to refer to a fixed installed
 device in the field (groundwater piezometer, surface water level
 measurement device).
 }
+\note{
+Up to and including \verb{watina 0.3.0}, the result was sorted according to
+\code{area_code}, \code{loc_code} and (for observation wells) \code{obswell_rank},
+both for the lazy query and the collected result.
+Later versions avoid sorting in case of a lazy result, because
+otherwise, when using the result inside another lazy query, this led to
+'ORDER BY' constructs in SQL subqueries, which must be avoided.
+If you like to print the lazy object in a sorted manner, you must add
+\verb{\%>\% arrange(...)} yourself.
+}
 \examples{
 \dontrun{
 watina <- connect_watina()

--- a/man/get_xg3.Rd
+++ b/man/get_xg3.Rd
@@ -86,6 +86,16 @@ Currently, non-truncated values are returned, with usage of estimated values.
 Why truncate, and why truncate by default?
 When to choose which \code{vert_crs}?)
 }
+\note{
+Up to and including \verb{watina 0.3.0}, the result was sorted according to
+\code{loc_code} and \code{hydroyear}, both for the lazy query and the
+collected result.
+Later versions avoid sorting in case of a lazy result, because
+otherwise, when using the result inside another lazy query, this led to
+'ORDER BY' constructs in SQL subqueries, which must be avoided.
+If you like to print the lazy object in a sorted manner, you must add
+\verb{\%>\% arrange(...)} yourself.
+}
 \examples{
 \dontrun{
 watina <- connect_watina()

--- a/man/get_xg3.Rd
+++ b/man/get_xg3.Rd
@@ -101,17 +101,22 @@ If you like to print the lazy object in a sorted manner, you must add
 watina <- connect_watina()
 library(dplyr)
 mylocs <- get_locs(watina, area_codes = "KAL")
-mylocs \%>\% get_xg3(watina, 2010)
+mylocs \%>\%
+    get_xg3(watina, 2010) \%>\%
+    arrange(loc_code, hydroyear)
 mylocs \%>\% get_xg3(watina, 2010, collect = TRUE)
-mylocs \%>\% get_xg3(watina, 2010, vert_crs = "ostend")
+mylocs \%>\%
+    get_xg3(watina, 2010, vert_crs = "ostend") \%>\%
+    arrange(loc_code, hydroyear)
 
 # joining results to mylocs:
 mylocs \%>\%
-  get_xg3(watina, 2010) \%>\%
-  left_join(mylocs \%>\%
-            select(-loc_wid),
-            .) \%>\%
-  collect
+    get_xg3(watina, 2010) \%>\%
+    left_join(mylocs \%>\%
+              select(-loc_wid),
+              .) \%>\%
+    collect \%>\%
+    arrange(loc_code, hydroyear)
 
 # Disconnect:
 DBI::dbDisconnect(watina)

--- a/man/selectlocs_chem.Rd
+++ b/man/selectlocs_chem.Rd
@@ -183,7 +183,7 @@ mylocs <- get_locs(watina, area_codes = "ZWA")
 mydata <-
     mylocs \%>\%
     get_chem(watina, "1/1/2010")
-mydata
+mydata \%>\% arrange(loc_code, date, chem_variable)
 mydata \%>\%
     pull(date) \%>\%
     lubridate::year(.) \%>\%

--- a/man/selectlocs_xg3.Rd
+++ b/man/selectlocs_xg3.Rd
@@ -279,7 +279,7 @@ mylocs <- get_locs(watina,
 mydata <-
  mylocs \%>\%
  get_xg3(watina, 2000)
-mydata
+mydata \%>\% arrange(loc_code, hydroyear)
 # Number of locations in mydata:
 mydata \%>\% distinct(loc_code) \%>\% count
 # Number of hydrological years per location and XG3 variable:


### PR DESCRIPTION
This fixes #63.

The functions `get_locs()`, `get_xg3()` and `get_chem()` now don't sort a lazy result anymore, because otherwise, when using the result inside another lazy query, this led to `ORDER BY` constructs in SQL subqueries, which must be avoided. Such cases throw a **warning** since `dbplyr` 2.0.0, and it appears to be prohibited by MS SQL.

Only with `collect = TRUE`, the sorting is still automatically taken care of by these functions.

If you like to print a resulting lazy object in a sorted manner, you must add `%>% arrange(...)` yourself.

Function documentation: examples in which lazy objects were printed, have been sorted accordingly. Vignettes will be dealt with in a separate PR.