### PR TITLE
pkgdown website: add quick installation method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,26 @@
+addons:
+  apt:
+    sources:
+      - sourceline: 'ppa:ubuntugis/ubuntugis-unstable'
+    packages:
+      - libudunits2-dev
+      - libgdal-dev
+      - libproj-dev
+      - libgeos-dev
+      - libfftw3-dev
+      - libfribidi-dev
+
 language: r
+
+dist: bionic
+
 cache: packages
 
 r_packages:
   - pkgdown
 
-r_github_packages:
-  - inbo/inborutils
-
-apt_packages:
-  - libudunits2-dev # For inborutils
-  - libgdal1-dev    # For inborutils
-  - libfftw3-dev    # For watina
-
 after_success:
-  - R CMD INSTALL . # Install the package to build vignettes
+  - R CMD INSTALL .
   - Rscript -e "pkgdown::build_site(preview = FALSE)"
 
 deploy:

--- a/README.md
+++ b/README.md
@@ -21,6 +21,17 @@ Currently the R package won't work outside INBO.
 
 ## Installing, testing and using the _watina_ package
 
+### Option 1 (quick): installing without vignettes
+
+```r
+Sys.setenv(R_REMOTES_NO_ERRORS_FROM_WARNINGS = "true") # as a precaution
+remotes::install_github("inbo/watina", upgrade = TRUE)
+```
+
+You can consult the vignettes of the latest release on the (this) `pkgdown` [website](https://inbo.github.io/watina/): click on 'Articles' at the top.
+
+### Option 2: installing with vignettes
+
 ```r
 Sys.setenv(R_REMOTES_NO_ERRORS_FROM_WARNINGS = "true") # as a precaution
 if (!("nycflights13" %in% installed.packages())) {


### PR DESCRIPTION
Fixes #68 .

Meanwhile cherry-picking 90f91d6 of `dev_nextrelease` with regard to Travis CI.