### PR TITLE
get_locs(): make obswell_aggr='mean' work again (was broken)

### DIFF
--- a/R/get.R
+++ b/R/get.R
@@ -597,8 +597,9 @@ get_locs <- function(con,
                                           sql("CAST(
                                               filterdepth_guessed AS bit)"))
                        } else .} %>%
-                       filter(row_number() == 1L) %>%
-                       ungroup()
+                       ungroup() %>%
+                       filter(.data$obswell_count == 1 |
+                                  .data$obswell_rank == .data$obswell_maxrank)
 
                    ) %>%
             select(-.data$obswell_code,


### PR DESCRIPTION
Fixes #79. Avoids the use of `row_number()`.

``` r
library(watina)
library(magrittr)
watina <- connect_watina()
get_locs(watina, area_codes = "WES", collect = TRUE) %>% nrow
#> [1] 79
get_locs(watina, area_codes = "WES", collect = TRUE,
         obswell_aggr = "latest_fd") %>% nrow
#> [1] 79
get_locs(watina, area_codes = "WES", collect = TRUE,
         obswell_aggr = "latest_sso") %>% nrow
#> [1] 79
get_locs(watina, area_codes = "WES", collect = TRUE,
         obswell_aggr = "mean") %>% nrow
#> [1] 79
```

<sup>Created on 2021-01-18 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>
<details>
<summary>
Session info
</summary>

``` r
devtools::session_info()
#> ─ Session info ───────────────────────────────────────────────────────────────
#>  setting  value                       
#>  version  R version 4.0.3 (2020-10-10)
#>  os       Linux Mint 20               
#>  system   x86_64, linux-gnu           
#>  ui       X11                         
#>  language nl_BE:nl                    
#>  collate  nl_BE.UTF-8                 
#>  ctype    nl_BE.UTF-8                 
#>  tz       Europe/Brussels             
#>  date     2021-01-18                  
#> 
#> ─ Packages ───────────────────────────────────────────────────────────────────
#>  package     * version    date       lib source                      
#>  assertthat    0.2.1      2019-03-21 [1] CRAN (R 4.0.2)              
#>  bit           4.0.4      2020-08-04 [1] CRAN (R 4.0.2)              
#>  bit64         4.0.5      2020-08-30 [1] CRAN (R 4.0.2)              
#>  blob          1.2.1      2020-01-20 [1] CRAN (R 4.0.2)              
#>  callr         3.5.1      2020-10-13 [1] CRAN (R 4.0.3)              
#>  class         7.3-17     2020-04-26 [4] CRAN (R 4.0.0)              
#>  classInt      0.4-3      2020-04-07 [1] CRAN (R 4.0.2)              
#>  cli           2.2.0      2020-11-20 [1] CRAN (R 4.0.3)              
#>  crayon        1.3.4      2017-09-16 [1] CRAN (R 4.0.2)              
#>  DBI           1.1.1      2021-01-15 [1] CRAN (R 4.0.3)              
#>  dbplyr        2.0.0      2020-11-03 [1] CRAN (R 4.0.3)              
#>  desc          1.2.0      2018-05-01 [1] CRAN (R 4.0.2)              
#>  devtools      2.3.2      2020-09-18 [1] CRAN (R 4.0.2)              
#>  dgof          1.2        2013-10-25 [1] CRAN (R 4.0.2)              
#>  digest        0.6.27     2020-10-24 [1] CRAN (R 4.0.3)              
#>  dplyr         1.0.3      2021-01-15 [1] CRAN (R 4.0.3)              
#>  e1071         1.7-4      2020-10-14 [1] CRAN (R 4.0.3)              
#>  ellipsis      0.3.1      2020-05-15 [1] CRAN (R 4.0.2)              
#>  evaluate      0.14       2019-05-28 [1] CRAN (R 4.0.2)              
#>  fansi         0.4.2      2021-01-15 [1] CRAN (R 4.0.3)              
#>  fs            1.5.0      2020-07-31 [1] CRAN (R 4.0.2)              
#>  generics      0.1.0      2020-10-31 [1] CRAN (R 4.0.3)              
#>  glue          1.4.2      2020-08-27 [1] CRAN (R 4.0.2)              
#>  highr         0.8        2019-03-20 [1] CRAN (R 4.0.2)              
#>  hms           1.0.0      2021-01-13 [1] CRAN (R 4.0.3)              
#>  htmltools     0.5.0      2020-06-16 [1] CRAN (R 4.0.2)              
#>  inbodb        0.0.0.9000 2021-01-18 [1] Github (inbo/inbodb@3d3990c)
#>  KernSmooth    2.23-18    2020-10-29 [4] CRAN (R 4.0.3)              
#>  knitr         1.30       2020-09-22 [1] CRAN (R 4.0.2)              
#>  KSgeneral     1.0.0      2020-10-02 [1] CRAN (R 4.0.2)              
#>  lifecycle     0.2.0      2020-03-06 [1] CRAN (R 4.0.2)              
#>  lubridate     1.7.9.2    2020-11-13 [1] CRAN (R 4.0.3)              
#>  magrittr    * 2.0.1      2020-11-17 [1] CRAN (R 4.0.3)              
#>  MASS          7.3-53     2020-09-09 [4] CRAN (R 4.0.2)              
#>  memoise       1.1.0      2017-04-21 [1] CRAN (R 4.0.2)              
#>  odbc          1.3.0      2020-10-27 [1] CRAN (R 4.0.3)              
#>  pillar        1.4.7      2020-11-20 [1] CRAN (R 4.0.3)              
#>  pkgbuild      1.2.0      2020-12-15 [1] CRAN (R 4.0.3)              
#>  pkgconfig     2.0.3      2019-09-22 [1] CRAN (R 4.0.2)              
#>  pkgload       1.1.0      2020-05-29 [1] CRAN (R 4.0.2)              
#>  prettyunits   1.1.1      2020-01-24 [1] CRAN (R 4.0.2)              
#>  processx      3.4.5      2020-11-30 [1] CRAN (R 4.0.3)              
#>  ps            1.5.0      2020-12-05 [1] CRAN (R 4.0.3)              
#>  purrr         0.3.4      2020-04-17 [1] CRAN (R 4.0.2)              
#>  R6            2.5.0      2020-10-28 [1] CRAN (R 4.0.3)              
#>  Rcpp          1.0.6      2021-01-15 [1] CRAN (R 4.0.3)              
#>  remotes       2.2.0      2020-07-21 [1] CRAN (R 4.0.2)              
#>  rlang         0.4.10     2020-12-30 [1] CRAN (R 4.0.3)              
#>  rmarkdown     2.6        2020-12-14 [1] CRAN (R 4.0.3)              
#>  rprojroot     2.0.2      2020-11-15 [1] CRAN (R 4.0.3)              
#>  sessioninfo   1.1.1      2018-11-05 [1] CRAN (R 4.0.2)              
#>  sf            0.9-7      2021-01-06 [1] CRAN (R 4.0.3)              
#>  stringi       1.5.3      2020-09-09 [1] CRAN (R 4.0.2)              
#>  stringr       1.4.0      2019-02-10 [1] CRAN (R 4.0.2)              
#>  testthat      3.0.1      2020-12-17 [1] CRAN (R 4.0.3)              
#>  tibble        3.0.5      2021-01-15 [1] CRAN (R 4.0.3)              
#>  tidyr         1.1.2      2020-08-27 [1] CRAN (R 4.0.2)              
#>  tidyselect    1.1.0      2020-05-11 [1] CRAN (R 4.0.2)              
#>  units         0.6-7      2020-06-13 [1] CRAN (R 4.0.2)              
#>  usethis       2.0.0      2020-12-10 [1] CRAN (R 4.0.3)              
#>  vctrs         0.3.6      2020-12-17 [1] CRAN (R 4.0.3)              
#>  watina      * 0.3.0.9000 2021-01-18 [1] Github (inbo/watina@ded217d)
#>  withr         2.4.0      2021-01-16 [1] CRAN (R 4.0.3)              
#>  xfun          0.20       2021-01-06 [1] CRAN (R 4.0.3)              
#>  yaml          2.2.1      2020-02-01 [1] CRAN (R 4.0.2)              
#> 
#> [1] /home/floris/lib/R/library
#> [2] /usr/local/lib/R/site-library
#> [3] /usr/lib/R/site-library
#> [4] /usr/lib/R/library
```

</details>