### PR TITLE
get_xg3(), get_chem(): make a local, not a global temporary table

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# watina 0.4.1 (2021-06-11)
+
+- Fixed non-working `get_xg3()` and `get_chem()` for dataframe input, by avoiding the currently defunct `dbplyr::db_drop_table()` (#89).
+- Various maintenance aspects (#81, #86, #87, #88)
+
 # watina 0.4.0 (2021-01-18)
 
 - This release has been made compatible with `dbplyr` 2.0.0 (on CRAN); the `dbplyr` fork is not needed anymore ([e66e58f](https://github.com/inbo/watina/commit/e66e58f), #74).

--- a/R/get.R
+++ b/R/get.R
@@ -831,13 +831,13 @@ get_xg3 <- function(locs,
 
         require_pkgs("DBI")
 
-        try(DBI::dbRemoveTable(con, "##locs"),
+        try(DBI::dbRemoveTable(con, "#locs"),
             silent = TRUE)
 
         locs <-
             copy_to(con,
                     locs,
-                    "##locs") %>%
+                    "#locs") %>%
             inner_join(tbl(con, "vwDimMeetpunt") %>%
                           select(loc_wid = .data$MeetpuntWID,
                                  loc_code = .data$MeetpuntCode),
@@ -1126,13 +1126,13 @@ get_chem <- function(locs,
 
         require_pkgs("DBI")
 
-        try(DBI::dbRemoveTable(con, "##locs"),
+        try(DBI::dbRemoveTable(con, "#locs"),
             silent = TRUE)
 
         locs <-
             copy_to(con,
                     locs,
-                    "##locs") %>%
+                    "#locs") %>%
             inner_join(tbl(con, "vwDimMeetpunt") %>%
                            select(loc_wid = .data$MeetpuntWID,
                                   loc_code = .data$MeetpuntCode),


### PR DESCRIPTION
See https://stackoverflow.com/questions/2920836/local-and-global-temporary-tables-in-sql-server/2921091#2921091

This prevents conflicts between multiple connections/users.
A global temp table is unneeded so a local one is more appropriate here.

This is a further hardening of both functions, on top of PR #89, in handling issue #85.