### PR TITLE
get_locs(): also substitute cases with filterlength == 0 by 0.3 m

### DIFF
--- a/R/get.R
+++ b/R/get.R
@@ -440,7 +440,8 @@ get_locs <- function(con,
         mutate(tubelength = ifelse(.data$PeilbuisLengte <= 0,
                                    NA,
                                    .data$PeilbuisLengte),
-               filterlength = ifelse(is.na(.data$FilterLengte),
+               filterlength = ifelse(is.na(.data$FilterLengte) |
+                                         .data$FilterLengte == 0,
                                      0.3,
                                      .data$FilterLengte),
                filterdepth = .data$tubelength -


### PR DESCRIPTION
Up to now, only missing values for filterlength were auto-replaced with 0.3 m.

As it appears that quite some records have a zero value for filterlength, it makes more sense to handle them the same way.

Below reprex shows behaviour of version 0.4.2.

``` r
library(watina)
library(dplyr, warn.conflicts = FALSE)
con <- connect_watina()
nrow_db <- function(x) count(x) |> pull()
get_locs(con, filterdepth_range = c(0, 100)) |> 
    nrow_db()
#> [1] 8472
get_locs(con, filterdepth_range = c(0, 100)) |> 
    filter(filterlength == 0) |> 
    nrow_db()
#> [1] 903
dbDisconnect(con)
```

<sup>Created on 2024-09-09 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

<details style="margin-bottom:10px;">
<summary>
Session info
</summary>

``` r
sessioninfo::session_info()
#> ─ Session info ───────────────────────────────────────────────────────────────
#>  setting  value
#>  version  R version 4.4.1 (2024-06-14)
#>  os       Linux Mint 21.3
#>  system   x86_64, linux-gnu
#>  ui       X11
#>  language nl_BE:nl
#>  collate  nl_BE.UTF-8
#>  ctype    nl_BE.UTF-8
#>  tz       Europe/Brussels
#>  date     2024-09-09
#>  pandoc   3.1.11 @ /usr/lib/rstudio/resources/app/bin/quarto/bin/tools/x86_64/ (via rmarkdown)
#> 
#> ─ Packages ───────────────────────────────────────────────────────────────────
#>  package     * version date (UTC) lib source
#>  assertthat    0.2.1   2019-03-21 [3] CRAN (R 4.0.1)
#>  bit           4.0.5   2022-11-15 [3] RSPM (R 4.2.0)
#>  bit64         4.0.5   2020-08-30 [3] RSPM (R 4.2.0)
#>  blob          1.2.4   2023-03-17 [3] RSPM (R 4.2.0)
#>  cli           3.6.3   2024-06-21 [3] RSPM (R 4.4.0)
#>  DBI           1.2.3   2024-06-02 [3] RSPM (R 4.4.0)
#>  dbplyr        2.5.0   2024-03-19 [3] RSPM (R 4.3.0)
#>  digest        0.6.37  2024-08-19 [3] RSPM (R 4.4.0)
#>  dplyr       * 1.1.4   2023-11-17 [3] RSPM (R 4.3.0)
#>  evaluate      0.24.0  2024-06-10 [3] RSPM (R 4.4.0)
#>  fansi         1.0.6   2023-12-08 [3] RSPM (R 4.3.0)
#>  fastmap       1.2.0   2024-05-15 [3] RSPM (R 4.4.0)
#>  fs            1.6.4   2024-04-25 [3] RSPM (R 4.3.0)
#>  generics      0.1.3   2022-07-05 [3] RSPM (R 4.2.0)
#>  glue          1.7.0   2024-01-09 [3] RSPM (R 4.3.0)
#>  hms           1.1.3   2023-03-21 [3] RSPM (R 4.2.0)
#>  htmltools     0.5.8.1 2024-04-04 [3] RSPM (R 4.3.0)
#>  inbodb        0.0.5   2024-08-14 [1] local
#>  knitr         1.48    2024-07-07 [3] RSPM (R 4.4.0)
#>  lifecycle     1.0.4   2023-11-07 [3] RSPM (R 4.3.0)
#>  lubridate     1.9.3   2023-09-27 [3] RSPM (R 4.3.0)
#>  magrittr      2.0.3   2022-03-30 [3] RSPM (R 4.2.0)
#>  odbc          1.5.0   2024-06-05 [3] RSPM (R 4.4.0)
#>  pillar        1.9.0   2023-03-22 [3] RSPM (R 4.2.0)
#>  pkgconfig     2.0.3   2019-09-22 [3] CRAN (R 4.0.1)
#>  purrr         1.0.2   2023-08-10 [3] RSPM (R 4.2.0)
#>  R6            2.5.1   2021-08-19 [3] RSPM (R 4.2.0)
#>  Rcpp          1.0.13  2024-07-17 [3] RSPM (R 4.4.0)
#>  reprex        2.1.1   2024-07-06 [3] RSPM (R 4.4.0)
#>  rlang         1.1.4   2024-06-04 [3] RSPM (R 4.4.0)
#>  rmarkdown     2.28    2024-08-17 [3] RSPM (R 4.4.0)
#>  rstudioapi    0.16.0  2024-03-24 [3] RSPM (R 4.3.0)
#>  sessioninfo   1.2.2   2021-12-06 [3] RSPM (R 4.2.0)
#>  stringi       1.8.4   2024-05-06 [3] RSPM (R 4.4.0)
#>  stringr       1.5.1   2023-11-14 [3] RSPM (R 4.3.0)
#>  tibble        3.2.1   2023-03-20 [3] RSPM (R 4.3.0)
#>  tidyr         1.3.1   2024-01-24 [3] RSPM (R 4.3.0)
#>  tidyselect    1.2.1   2024-03-11 [3] RSPM (R 4.3.0)
#>  timechange    0.3.0   2024-01-18 [3] RSPM (R 4.3.0)
#>  utf8          1.2.4   2023-10-22 [3] RSPM (R 4.3.0)
#>  vctrs         0.6.5   2023-12-01 [3] RSPM (R 4.3.0)
#>  watina      * 0.4.2   2024-09-09 [1] https://inbo.r-universe.dev (R 4.4.1)
#>  withr         3.0.1   2024-07-31 [3] RSPM (R 4.4.0)
#>  xfun          0.47    2024-08-17 [3] RSPM (R 4.4.0)
#>  yaml          2.3.10  2024-07-26 [3] RSPM (R 4.4.0)
#> 
#>  [1] /home/floris/lib/R/library
#>  [2] /usr/local/lib/R/site-library
#>  [3] /usr/lib/R/site-library
#>  [4] /usr/lib/R/library
#> 
#> ──────────────────────────────────────────────────────────────────────────────
```

</details>