### PR TITLE
noNA conflict of `assertthat` and `terra`

### DIFF
--- a/R/eval.R
+++ b/R/eval.R
@@ -669,7 +669,7 @@ eval_chem <- function(data,
 date, lab_sample_id, chem_variable, value, unit, below_loq."
     )
 
-    assert_that(is.flag(uniformity_test), noNA(uniformity_test))
+    assert_that(is.flag(uniformity_test), assertthat::noNA(uniformity_test))
 
     data <-
         data %>%

--- a/R/get.R
+++ b/R/get.R
@@ -348,11 +348,11 @@ get_locs <- function(con,
     assert_that(is.null(area_codes) | all(is.character(area_codes)))
     assert_that(is.null(loc_vec) | all(is.character(loc_vec)),
                 msg = "loc_vec must be a character vector.")
-    assert_that(is.flag(join_mask), noNA(join_mask))
-    assert_that(is.flag(collect), noNA(collect))
-    assert_that(is.flag(obswells), noNA(obswells))
-    assert_that(is.flag(filterdepth_guess), noNA(filterdepth_guess))
-    assert_that(is.flag(filterdepth_na), noNA(filterdepth_na))
+    assert_that(is.flag(join_mask), assertthat::noNA(join_mask))
+    assert_that(is.flag(collect), assertthat::noNA(collect))
+    assert_that(is.flag(obswells), assertthat::noNA(obswells))
+    assert_that(is.flag(filterdepth_guess), assertthat::noNA(filterdepth_guess))
+    assert_that(is.flag(filterdepth_na), assertthat::noNA(filterdepth_na))
 
     obswell_aggr <- match.arg(obswell_aggr)
 
@@ -822,8 +822,8 @@ get_xg3 <- function(locs,
                 msg = "startyear must not be larger than endyear.")
     assert_that("loc_code" %in% colnames(locs),
                 msg = "locs does not have a column name 'loc_code'.")
-    assert_that(is.flag(truncated), noNA(truncated))
-    assert_that(is.flag(collect), noNA(collect))
+    assert_that(is.flag(truncated), assertthat::noNA(truncated))
+    assert_that(is.flag(collect), assertthat::noNA(collect))
 
     if (inherits(locs, "data.frame")) {
         locs <-
@@ -1112,8 +1112,8 @@ get_chem <- function(locs,
                 en_range[1] >= -1,
                 en_range[2] <= 1
                 )
-    assert_that(is.flag(en_exclude_na), noNA(en_exclude_na))
-    assert_that(is.flag(collect), noNA(collect))
+    assert_that(is.flag(en_exclude_na), assertthat::noNA(en_exclude_na))
+    assert_that(is.flag(collect), assertthat::noNA(collect))
 
     if (!is.na(en_fecond_threshold) & !is.null(en_fecond_threshold)) {
         assert_that(is.number(en_fecond_threshold),

--- a/R/selectlocs.R
+++ b/R/selectlocs.R
@@ -360,8 +360,8 @@ selectlocs_xg3 <- function(data,
     }
 
     assert_that(inherits(conditions, "data.frame"))
-    assert_that(is.flag(verbose), noNA(verbose))
-    assert_that(is.flag(list), noNA(list))
+    assert_that(is.flag(verbose), assertthat::noNA(verbose))
+    assert_that(is.flag(list), assertthat::noNA(list))
 
     assert_that(all(c("xg3_variable",
                   "statistic",
@@ -967,8 +967,8 @@ selectlocs_chem <- function(data,
     }
 
     assert_that(inherits(conditions, "data.frame"))
-    assert_that(is.flag(verbose), noNA(verbose))
-    assert_that(is.flag(list), noNA(list))
+    assert_that(is.flag(verbose), assertthat::noNA(verbose))
+    assert_that(is.flag(list), assertthat::noNA(list))
 
     assert_that(all(c("chem_variable",
                       "statistic",
@@ -1167,8 +1167,8 @@ selectlocs <- function(data,
     }
 
     assert_that(inherits(conditions, "data.frame"))
-    assert_that(is.flag(verbose), noNA(verbose))
-    assert_that(is.flag(list), noNA(list))
+    assert_that(is.flag(verbose), assertthat::noNA(verbose))
+    assert_that(is.flag(list), assertthat::noNA(list))
 
     assert_that(all(c("variable",
                       "statistic",

--- a/R/sf.R
+++ b/R/sf.R
@@ -54,7 +54,7 @@ as_points <- function(df,
     assert_that(is.string(yvar))
     assert_that(has_name(df, xvar))
     assert_that(has_name(df, yvar))
-    assert_that(is.flag(warn_dupl), noNA(warn_dupl))
+    assert_that(is.flag(warn_dupl), assertthat::noNA(warn_dupl))
 
     require_pkgs("sf")
 


### PR DESCRIPTION
The [`assertthat::noNA` check](https://www.rdocumentation.org/packages/assertthat/versions/0.2.1/topics/noNA) used in assertions might be masked by [the `terra::noNA` function](https://rspatial.github.io/terra/reference/summarize-generics.html?q=noNA).
In those cases, the not-too-instructive error message is thrown:
```
> noNA(join_mask)
Error: unable to find an inherited method for function `noNA` for signature `x = "logical"`
```

This happened to me when using modules of the `watina` package in a non-RStudio context; I think the `roxygen::@importFrom` requirements prevent the error, for the majority of users. (I cannot tell whether those implicit imports run correctly in debugging contexts.)
However, combined use of `terra` and `watina` is quite common, we can not ensure IDE 100%, and the change is minor effort, so I would argue for an explicit call of `assertthat::noNA`.

The suggested change is nothing more than that: all `noNA` calls are replaced by `assertthat::noNA`.

_Note: this is supposed to merge into `dev_nextrelease`, I hope I did it right with the PR._