### PR TITLE
Protecting get_chem() against 'Divide by zero error' in fecond calculation

### DIFF
--- a/R/get.R
+++ b/R/get.R
@@ -1428,7 +1428,8 @@ get_chem <- function(locs,
       chemdata %>%
       # temporary value:
       mutate(lab_sample_id = sql("CAST(StaalID AS varchar)")) %>%
-      select(.data$lab_sample_id,
+      select(
+        .data$lab_sample_id,
         chem_variable = .data$ChemVarCode,
         value_eq = .data$MeetwaardeMEQ
       ) %>%
@@ -1458,15 +1459,19 @@ get_chem <- function(locs,
       if (is.na(en_fecond_threshold) | is.null(en_fecond_threshold)) {
         # I.1 applying the en_range condition:
         chem %>%
-          filter((!is.na(.data$elneutr) & sql(sqlstring_en)) |
-            .data$provide_eq_unit == "FALSE")
+          filter(
+            (!is.na(.data$elneutr) & sql(sqlstring_en)) |
+              .data$provide_eq_unit == "FALSE"
+          )
       } else {
         # I.2 applying the en_fecond_threshold OR the en_range condition:
         chem %>%
           left_join(samples_fecond, by = "lab_sample_id") %>%
-          filter((!is.na(.data$elneutr) & sql(sqlstring_en)) |
-            .data$fecond >= en_fecond_threshold |
-            .data$provide_eq_unit == "FALSE") %>%
+          filter(
+            (!is.na(.data$elneutr) & sql(sqlstring_en)) |
+              .data$fecond >= en_fecond_threshold |
+              .data$provide_eq_unit == "FALSE"
+          ) %>%
           select(-.data$fecond)
       }
     } else {
@@ -1474,17 +1479,21 @@ get_chem <- function(locs,
       if (is.na(en_fecond_threshold) | is.null(en_fecond_threshold)) {
         # II.1 applying the en_range condition:
         chem %>%
-          filter(is.na(.data$elneutr) |
-            sql(sqlstring_en) |
-            .data$provide_eq_unit == "FALSE")
+          filter(
+            is.na(.data$elneutr) |
+              sql(sqlstring_en) |
+              .data$provide_eq_unit == "FALSE"
+          )
       } else {
         # II.2 applying the en_fecond_threshold OR the en_range condition:
         chem %>%
           left_join(samples_fecond, by = "lab_sample_id") %>%
-          filter(is.na(.data$elneutr) |
-            sql(sqlstring_en) |
-            .data$fecond >= en_fecond_threshold |
-            .data$provide_eq_unit == "FALSE") %>%
+          filter(
+            is.na(.data$elneutr) |
+              sql(sqlstring_en) |
+              .data$fecond >= en_fecond_threshold |
+              .data$provide_eq_unit == "FALSE"
+          ) %>%
           select(-.data$fecond)
       }
     }

--- a/R/get.R
+++ b/R/get.R
@@ -1424,6 +1424,20 @@ get_chem <- function(locs,
 
   # preparing for the application of the en_fecond_threshold:
   if (!is.na(en_fecond_threshold) & !is.null(en_fecond_threshold)) {
+    if (any(
+      chemdata %>%
+      filter(
+        .data$ChemVarCode == "CondL",
+        !is.na(.data$MeetwaardeMEQ)
+      ) %>%
+      pull(.data$MeetwaardeMEQ) == 0
+    )) {
+      warning(
+        "Zeroes for 'CondL' (lab conductivity) detected. ",
+        "These rows will be ignored in calculating the iron / conductivity ",
+        "ratio for the `fecond` condition."
+      )
+    }
     samples_fecond <-
       chemdata %>%
       # temporary value:

--- a/R/get.R
+++ b/R/get.R
@@ -1441,7 +1441,9 @@ get_chem <- function(locs,
         names_from = .data$chem_variable,
         values_from = .data$value_eq
       ) %>%
-      mutate(fecond = .data$Fe / .data$CondL) %>%
+      mutate(
+        fecond = .data$Fe / ifelse(.data$CondL == 0, NA_real_, .data$CondL)
+      ) %>%
       select(
         .data$lab_sample_id,
         .data$fecond

--- a/R/get.R
+++ b/R/get.R
@@ -1435,7 +1435,7 @@ get_chem <- function(locs,
       warning(
         "Zeroes for 'CondL' (lab conductivity) detected. ",
         "These rows will be ignored in calculating the iron / conductivity ",
-        "ratio for the `fecond` condition."
+        "ratio for the `en_fecond_threshold` condition."
       )
     }
     samples_fecond <-

--- a/R/get.R
+++ b/R/get.R
@@ -1242,6 +1242,7 @@ get_xg3 <- function(locs,
 #' arrange
 #' distinct
 #' sql
+#' rename
 get_chem <- function(locs,
                      con,
                      startdate,
@@ -1322,8 +1323,8 @@ get_chem <- function(locs,
       )
   }
 
-
-  chem <-
+  # filter chemistry data for dates and locations
+  chemdata <-
     tbl(con, "FactChemischeMeting") %>%
     select(
       .data$StaalID,
@@ -1352,6 +1353,26 @@ get_chem <- function(locs,
       by = "DatumWID"
     ) %>%
     mutate(Datum = sql("CAST(Datum AS date)")) %>%
+    filter(
+      .data$Datum >= startdate,
+      .data$Datum <= enddate
+    ) %>%
+    rename(loc_wid = .data$MeetpuntWID) %>%
+    inner_join(
+      locs %>%
+        select(
+          .data$loc_wid,
+          .data$loc_code
+        ) %>%
+        distinct(),
+      .,
+      by = "loc_wid"
+    ) %>%
+    select(-.data$loc_wid)
+
+  # add relevant further attributes and rename
+  chem <-
+    chemdata %>%
     left_join(
       tbl(con, "ssrs_StaalEN") %>%
         select(
@@ -1360,10 +1381,6 @@ get_chem <- function(locs,
         ),
       by = "StaalID"
     ) %>%
-    filter(
-      .data$Datum >= startdate,
-      .data$Datum <= enddate
-    ) %>%
     # temporary values:
     mutate(
       lab_project_id = "0",
@@ -1371,7 +1388,7 @@ get_chem <- function(locs,
       loq = -99
     ) %>%
     select(
-      loc_wid = .data$MeetpuntWID,
+      .data$loc_code,
       date = .data$Datum,
       .data$lab_project_id,
       .data$lab_sample_id,
@@ -1395,18 +1412,7 @@ get_chem <- function(locs,
                  ELSE 0
                  END) AS bit)"
         )
-    ) %>%
-    inner_join(
-      locs %>%
-        select(
-          .data$loc_wid,
-          .data$loc_code
-        ) %>%
-        distinct(),
-      .,
-      by = "loc_wid"
-    ) %>%
-    select(-.data$loc_wid)
+    )
 
   sqlstring_en <-
     paste0(
@@ -1419,34 +1425,7 @@ get_chem <- function(locs,
   # preparing for the application of the en_fecond_threshold:
   if (!is.na(en_fecond_threshold) & !is.null(en_fecond_threshold)) {
     samples_fecond <-
-      tbl(con, "FactChemischeMeting") %>%
-      select(
-        .data$StaalID,
-        .data$DatumWID,
-        .data$ChemVarWID,
-        .data$MeetwaardeMEQ
-      ) %>%
-      inner_join(
-        tbl(con, "DimChemVar") %>%
-          select(
-            .data$ChemVarWID,
-            .data$ChemVarCode
-          ),
-        by = "ChemVarWID"
-      ) %>%
-      inner_join(
-        tbl(con, "DimTijd") %>%
-          select(
-            .data$DatumWID,
-            .data$Datum
-          ),
-        by = "DatumWID"
-      ) %>%
-      mutate(Datum = sql("CAST(Datum AS date)")) %>%
-      filter(
-        .data$Datum >= startdate,
-        .data$Datum <= enddate
-      ) %>%
+      chemdata %>%
       # temporary value:
       mutate(lab_sample_id = sql("CAST(StaalID AS varchar)")) %>%
       select(.data$lab_sample_id,

--- a/watina.Rproj
+++ b/watina.Rproj
@@ -20,3 +20,5 @@ BuildType: Package
 PackageUseDevtools: Yes
 PackageInstallArgs: --no-multiarch --with-keep.source
 PackageRoxygenize: rd,collate,namespace
+
+UseNativePipeOperator: No


### PR DESCRIPTION
This fixes #116 by implementing the proposals made in https://github.com/inbo/watina/issues/116#issuecomment-4154748031.

~It seems that @fredericpiesschaert already replaced the zero values in the database, as the problem has gone for "RAV" without warning when using either the code of this branch or from current `dev_nextrelease`.~ ==> no, I just didn't filter for the problematic locations. Solved below in https://github.com/inbo/watina/pull/122#issuecomment-4155424392.

Tell me @cecileherr @fredericpiesschaert if you wish to review / test, so that I wait before merging this PR.